### PR TITLE
Applying handy SO_REUSEADDR to kernel to reuse a local socket in TIME…

### DIFF
--- a/graphyte.py
+++ b/graphyte.py
@@ -99,6 +99,7 @@ class Sender:
     def send_message(self, message):
         if self.protocol == 'tcp':
             sock = socket.create_connection((self.host, self.port), self.timeout)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             try:
                 sock.send(message)
             finally:  # sockets don't support "with" statement on Python 2.x


### PR DESCRIPTION
…_WAIT state, without waiting for its natural timeout to expire.

In my environment i was seeing lots of time waits and messages like
2017-08-18 12:49:17,913 error sending message 'xxxxx 0 1503053358\n': [Errno 99] Cannot assign requested address
2017-08-18 12:49:17,916 error sending message 'sxxxxx 1 1503053358\n': [Errno 99] Cannot assign requested address

