### PR TITLE
Add batch limit to message sender in async mode

### DIFF
--- a/graphyte.py
+++ b/graphyte.py
@@ -171,8 +171,8 @@ class Sender:
             if current_time - last_check_time >= self.interval:
                 last_check_time = current_time
                 for i in range(0, len(messages), self.batch_size):
-                        batch = messages[i:i + self.batch_size]
-                        self.send_socket(b''.join(batch))
+                   batch = messages[i:i + self.batch_size]
+                   self.send_socket(b''.join(batch))
                 messages = []
 
         # Send any final messages before exiting thread

--- a/graphyte.py
+++ b/graphyte.py
@@ -28,10 +28,11 @@ logger = logging.getLogger(__name__)
 
 class Sender:
     def __init__(self, host, port=2003, prefix=None, timeout=5, interval=None,
-                 queue_size=None, log_sends=False, protocol='tcp',send_batchsize=1000):
+                 queue_size=None, log_sends=False, protocol='tcp', batch_size=1000):
         """Initialize a Sender instance, starting the background thread to
         send messages at given interval (in seconds) if "interval" is not
-        None. Default protocol is TCP; use protocol='udp' for UDP.
+        None. Send at most "batch_size" messages per socket send operation. (default=1000).
+        Default protocol is TCP; use protocol='udp' for UDP.        
         """
         self.host = host
         self.port = port
@@ -40,7 +41,7 @@ class Sender:
         self.interval = interval
         self.log_sends = log_sends
         self.protocol = protocol
-        self.send_batchsize = send_batchsize
+        self.batch_size = batch_size
 
         if self.interval is not None:
             if queue_size is None:
@@ -172,7 +173,7 @@ class Sender:
                 if messages:
                     while messages:
                         batch_messages = []
-                        count_to_send = min(self.send_batchsize,len(messages))
+                        count_to_send = min(self.batch_size, len(messages))
                         for x in range(count_to_send):
                             batch_messages.append( messages.pop(0) )
                         self.send_socket(b''.join(batch_messages))

--- a/graphyte.py
+++ b/graphyte.py
@@ -172,11 +172,12 @@ class Sender:
                 last_check_time = current_time
                 if messages:
                     while messages:
-                        batch_messages = []
                         count_to_send = min(self.batch_size, len(messages))
-                        for x in range(count_to_send):
-                            batch_messages.append( messages.pop(0) )
-                        self.send_socket(b''.join(batch_messages))
+                        # Move batch from messages to batch 
+			batch = messages[0:count_to_send]
+                        del messages[0:count_to_send]
+			# Send batch
+			self.send_socket(b''.join(batch))
                     messages = []
 
         # Send any final messages before exiting thread

--- a/graphyte.py
+++ b/graphyte.py
@@ -40,7 +40,7 @@ class Sender:
         self.interval = interval
         self.log_sends = log_sends
         self.protocol = protocol
-	self.send_batchsize = send_batchsize
+        self.send_batchsize = send_batchsize
 
         if self.interval is not None:
             if queue_size is None:

--- a/graphyte.py
+++ b/graphyte.py
@@ -171,7 +171,7 @@ class Sender:
                 last_check_time = current_time
                 if messages:
                     while messages:
-			batch_messages = []
+                        batch_messages = []
                         count_to_send = min(self.send_batchsize,len(messages))
                         for x in range(count_to_send):
                             batch_messages.append( messages.pop(0) )

--- a/graphyte.py
+++ b/graphyte.py
@@ -174,15 +174,21 @@ class Sender:
                     while messages:
                         count_to_send = min(self.batch_size, len(messages))
                         # Move batch from messages to batch 
-			batch = messages[0:count_to_send]
+                        batch = messages[0:count_to_send]
                         del messages[0:count_to_send]
-			# Send batch
-			self.send_socket(b''.join(batch))
+                        # Send batch
+                        self.send_socket(b''.join(batch))
                     messages = []
 
         # Send any final messages before exiting thread
         if messages:
-            self.send_socket(b''.join(messages))
+             while messages:
+                 count_to_send = min(self.batch_size, len(messages))
+                 # Move batch from messages to batch 
+                 batch = messages[0:count_to_send]
+                 del messages[0:count_to_send]
+                 # Send batch
+                 self.send_socket(b''.join(batch))
 
 
 def init(*args, **kwargs):

--- a/graphyte.py
+++ b/graphyte.py
@@ -31,7 +31,7 @@ class Sender:
                  queue_size=None, log_sends=False, protocol='tcp', batch_size=1000):
         """Initialize a Sender instance, starting the background thread to
         send messages at given interval (in seconds) if "interval" is not
-        None. Send at most "batch_size" messages per socket send operation. (default=1000).
+        None. Send at most "batch_size" messages per socket send operation (default=1000).
         Default protocol is TCP; use protocol='udp' for UDP.        
         """
         self.host = host
@@ -170,26 +170,15 @@ class Sender:
             current_time = time.time()
             if current_time - last_check_time >= self.interval:
                 last_check_time = current_time
-                if messages:
-                    while messages:
-                        count_to_send = min(self.batch_size, len(messages))
-                        # Move batch from messages to batch 
-                        batch = messages[0:count_to_send]
-                        del messages[0:count_to_send]
-                        # Send batch
+                for i in range(0, len(messages), self.batch_size):
+                        batch = messages[i:i + self.batch_size]
                         self.send_socket(b''.join(batch))
-                    messages = []
+                messages = []
 
         # Send any final messages before exiting thread
-        if messages:
-             while messages:
-                 count_to_send = min(self.batch_size, len(messages))
-                 # Move batch from messages to batch 
-                 batch = messages[0:count_to_send]
-                 del messages[0:count_to_send]
-                 # Send batch
-                 self.send_socket(b''.join(batch))
-
+        for i in range(0, len(messages), self.batch_size):
+            batch = messages[i:i + self.batch_size]
+            self.send_socket(b''.join(batch))
 
 def init(*args, **kwargs):
     """Initialize default Sender instance with given args."""

--- a/test_graphyte.py
+++ b/test_graphyte.py
@@ -157,7 +157,7 @@ class TestInterval(unittest.TestCase):
 
 class TestIntervalBatch(unittest.TestCase):
     def setUp(self):
-        self.sender = TestSender(interval=0.1,send_batchsize=5)
+        self.sender = TestSender(interval=0.1,batch_size=5)
 
     def tearDown(self):
         self.sender.stop()

--- a/test_graphyte.py
+++ b/test_graphyte.py
@@ -155,6 +155,29 @@ class TestInterval(unittest.TestCase):
         time.sleep(0.2)
         self.assertEqual(self.sender.pop_message(), b'buz 45 12348\n')
 
+class TestIntervalBatch(unittest.TestCase):
+    def setUp(self):
+        self.sender = TestSender(interval=0.1,send_batchsize=5)
+
+    def tearDown(self):
+        self.sender.stop()
+
+    def test_send_many_multiple(self):
+        self.sender.send('foo', 42, timestamp=12345)
+        self.sender.send('bar', 43, timestamp=12346)
+        self.sender.send('baz', 44, timestamp=12347)
+        self.sender.send('baz', 45, timestamp=12348)
+        self.sender.send('baz', 46, timestamp=12349)
+        self.sender.send('baz', 47, timestamp=12350)
+        time.sleep(0.2)
+        self.assertEqual(self.sender.pop_message(),
+                         b'foo 42 12345\nbar 43 12346\nbaz 44 12347\nbaz 45 12348\nbaz 46 12349\n')
+        self.assertEqual(self.sender.pop_message(),
+                         b'baz 47 12350\n')
+
+        self.sender.send('buz', 45, timestamp=12348)
+        time.sleep(0.2)
+        self.assertEqual(self.sender.pop_message(), b'buz 45 12348\n')
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_graphyte.py
+++ b/test_graphyte.py
@@ -157,7 +157,7 @@ class TestInterval(unittest.TestCase):
 
 class TestIntervalBatch(unittest.TestCase):
     def setUp(self):
-        self.sender = TestSender(interval=0.1,batch_size=5)
+        self.sender = TestSender(interval=0.1, batch_size=5)
 
     def tearDown(self):
         self.sender.stop()


### PR DESCRIPTION
This should allow default batching of messages to 1000, which is graphite's default for the max on the line receiver protocol.

Fixes: #7 