### PR TITLE
Validation for tag keys and values

### DIFF
--- a/graphyte.py
+++ b/graphyte.py
@@ -72,7 +72,13 @@ class Sender:
             raise TypeError('"value" must be an int or a float, not a {}'.format(
                 type(value).__name__))
 
-        tags_suffix = ''.join(';{}={}'.format(x[0], x[1]) for x in sorted(tags.items()))
+        tags_suffix = ''
+
+        for x in sorted(tags.items()):
+            if not x[0] or str(x[0]).split(None, 1)[0] != str(x[0]) or not x[1] or str(x[1]).split(None, 1)[0] != str(x[1]):
+                raise ValueError('"tags" must not have whitespace in it')
+
+            tags_suffix += ';{}={}'.format(x[0], x[1])
 
         message = u'{}{}{} {} {}\n'.format(
             self.prefix + '.' if self.prefix else '',

--- a/graphyte.py
+++ b/graphyte.py
@@ -25,6 +25,8 @@ __version__ = '1.5'
 default_sender = None
 logger = logging.getLogger(__name__)
 
+def has_whitespace(value):
+    return not value or str(value).split(None, 1)[0] != str(value)
 
 class Sender:
     def __init__(self, host, port=2003, prefix=None, timeout=5, interval=None,
@@ -66,7 +68,7 @@ class Sender:
 
     def build_message(self, metric, value, timestamp, tags={}):
         """Build a Graphite message to send and return it as a byte string."""
-        if not metric or metric.split(None, 1)[0] != metric:
+        if has_whitespace(metric):
             raise ValueError('"metric" must not have whitespace in it')
         if not isinstance(value, (int, float)):
             raise TypeError('"value" must be an int or a float, not a {}'.format(
@@ -75,7 +77,7 @@ class Sender:
         tags_suffix = ''
 
         for x in sorted(tags.items()):
-            if not x[0] or str(x[0]).split(None, 1)[0] != str(x[0]) or not x[1] or str(x[1]).split(None, 1)[0] != str(x[1]):
+            if has_whitespace(x[0]) or has_whitespace(x[1]):
                 raise ValueError('"tags" must not have whitespace in it')
 
             tags_suffix += ';{}={}'.format(x[0], x[1])

--- a/graphyte.py
+++ b/graphyte.py
@@ -26,7 +26,11 @@ default_sender = None
 logger = logging.getLogger(__name__)
 
 def has_whitespace(value):
-    return not value or str(value).split(None, 1)[0] != str(value)
+    if type(value) == int:
+        value = str(value)
+    if type(value) == str:
+        value = value.encode('utf-8')
+    return not value or value.split(None, 1)[0] != value
 
 class Sender:
     def __init__(self, host, port=2003, prefix=None, timeout=5, interval=None,

--- a/test_graphyte.py
+++ b/test_graphyte.py
@@ -68,6 +68,8 @@ class TestBuildMessage(unittest.TestCase):
             sender.build_message('foo.bar', 42, 123456, tags={'ab c': '123'})
         with self.assertRaises(ValueError):
             sender.build_message('foo.bar', 42, 123456, tags={'abc': '1 23'})
+        with self.assertRaises(ValueError):
+            sender.build_message({'dict':'value'}, 42, 123456, tags={'abc': '1 23'})
 
     def test_tagging_none(self):
         sender = TestSender()
@@ -83,6 +85,11 @@ class TestBuildMessage(unittest.TestCase):
         sender = TestSender()
         self.assertEqual(sender.build_message('tag.test', 42, 12345, {'foo': 123}),
                          b'tag.test;foo=123 42 12345\n')
+
+    def test_tagging_unicode(self):
+        sender = TestSender()
+        self.assertEqual(sender.build_message('tag.test', 42, 12345, {u'\u201cfoo.bar\u201d': 123}),
+                         b'tag.test;\xe2\x80\x9cfoo.bar\xe2\x80\x9d=123 42 12345\n')
 
     def test_tagging_multi(self):
         sender = TestSender()

--- a/test_graphyte.py
+++ b/test_graphyte.py
@@ -64,6 +64,10 @@ class TestBuildMessage(unittest.TestCase):
             sender.build_message('foo.bar', 'x', 12346)
         with self.assertRaises(ValueError):
             sender.build_message('foo bar', 42, 12346)
+        with self.assertRaises(ValueError):
+            sender.build_message('foo.bar', 42, 123456, tags={'ab c': '123'})
+        with self.assertRaises(ValueError):
+            sender.build_message('foo.bar', 42, 123456, tags={'abc': '1 23'})
 
     def test_tagging_none(self):
         sender = TestSender()
@@ -74,6 +78,11 @@ class TestBuildMessage(unittest.TestCase):
         sender = TestSender()
         self.assertEqual(sender.build_message('tag.test', 42, 12345, {'foo': 'bar'}),
                          b'tag.test;foo=bar 42 12345\n')
+    
+    def test_tagging_numeric_value(self):
+        sender = TestSender()
+        self.assertEqual(sender.build_message('tag.test', 42, 12345, {'foo': 123}),
+                         b'tag.test;foo=123 42 12345\n')
 
     def test_tagging_multi(self):
         sender = TestSender()


### PR DESCRIPTION
- Invalid values on tags were creating an invalid message to graphite. Added a validation similar to metric name to validate whitespaces.
- Added tests to simulate that exception.
