### PR TITLE
Use sendall() when writing into TCP socket.

### DIFF
--- a/graphyte.py
+++ b/graphyte.py
@@ -115,7 +115,7 @@ class Sender:
             sock = socket.create_connection((self.host, self.port), self.timeout)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             try:
-                sock.send(message)
+                sock.sendall(message)
             finally:  # sockets don't support "with" statement on Python 2.x
                 sock.close()
         elif self.protocol == 'udp':


### PR DESCRIPTION
It is not guaranteed `send()` actually sends all the passed bytes. `sendall()` does.' 