### PR TITLE
Add support for default tags

### DIFF
--- a/graphyte.py
+++ b/graphyte.py
@@ -32,7 +32,7 @@ def _has_whitespace(value):
 
 class Sender:
     def __init__(self, host, port=2003, prefix=None, timeout=5, interval=None,
-                 queue_size=None, log_sends=False, protocol='tcp', batch_size=1000):
+                 queue_size=None, log_sends=False, protocol='tcp', batch_size=1000, tags={}):
         """Initialize a Sender instance, starting the background thread to
         send messages at given interval (in seconds) if "interval" is not
         None. Send at most "batch_size" messages per socket send operation (default=1000).
@@ -46,6 +46,7 @@ class Sender:
         self.log_sends = log_sends
         self.protocol = protocol
         self.batch_size = batch_size
+        self.tags = tags
 
         if self.interval is not None:
             if queue_size is None:
@@ -76,7 +77,9 @@ class Sender:
             raise TypeError('"value" must be an int or a float, not a {}'.format(
                 type(value).__name__))
 
-        tags_strs = [u';{}={}'.format(k, v) for k, v in sorted(tags.items())]
+        default_tags = self.tags.copy()
+        default_tags.update(tags)
+        tags_strs = [u';{}={}'.format(k, v) for k, v in sorted(default_tags.items())]
         if any(_has_whitespace(t) for t in tags_strs):
             raise ValueError('"tags" keys and values must not have whitespace in them')
         tags_suffix = ''.join(tags_strs)

--- a/test_graphyte.py
+++ b/test_graphyte.py
@@ -94,6 +94,26 @@ class TestBuildMessage(unittest.TestCase):
         self.assertEqual(sender.build_message('tag.test', 42, 12345, {'foo': 'bar', 'ding': 'dong'}),
                          b'tag.test;ding=dong;foo=bar 42 12345\n')
 
+    def test_tagging_default(self):
+        sender = TestSender(tags={'foo': 'bar'})
+        self.assertEqual(sender.build_message('tag.test', 42, 12345),
+                         b'tag.test;foo=bar 42 12345\n')
+
+    def test_tagging_override(self):
+        sender = TestSender(tags={'foo': 'bar', 'ding': 'dong'})
+        self.assertEqual(sender.build_message('tag.test', 42, 12345, {'foo': 'not-bar'}),
+                         b'tag.test;ding=dong;foo=not-bar 42 12345\n')
+
+    def test_tagging_default_no_overlap(self):
+        sender = TestSender(tags={'foo': 'bar'})
+        self.assertEqual(sender.build_message('tag.test', 42, 12345, {'ding': 'dong'}),
+                         b'tag.test;ding=dong;foo=bar 42 12345\n')
+
+    def test_tagging_default_multi(self):
+        sender = TestSender(tags={'foobar': 42, 'py': 'thon'})
+        self.assertEqual(sender.build_message('tag.test', 42, 12345, {'foo': 'bar', 'ding': 'dong'}),
+                         b'tag.test;ding=dong;foo=bar;foobar=42;py=thon 42 12345\n')
+
 class TestSynchronous(unittest.TestCase):
     def test_timestamp_specified(self):
         sender = TestSender()


### PR DESCRIPTION
This commit adds support for default tags.

What this does is it allows for common tags, such as session ID,
environment, etc. to be included in all metrics sent. This commit also
allows for those tags to be overridden.